### PR TITLE
Quiz Entity and QuizDataAccess Implementation

### DIFF
--- a/src/data_access/QuizDataAccessObject.java
+++ b/src/data_access/QuizDataAccessObject.java
@@ -1,0 +1,71 @@
+package data_access;
+
+import com.mongodb.client.*;
+import entity.Quiz;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import use_case.quiz.QuizDataAccessInterface;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class QuizDataAccessObject implements QuizDataAccessInterface, Database {
+    private MongoClient mongoClient;
+    private MongoDatabase mongoDatabase;
+
+    private final String databaseName = "CSC207CourseProject";
+    final String password = "wHobkrGFVf089B3d";
+
+    final String connectionString = "mongodb+srv://mintunxd:" + password + "@csc207courseproject.w8yhgiq.mongodb.net/?retryWrites=true&w=majority";
+
+    // Codec for MongoDB
+    CodecProvider pojoCodecProvider = PojoCodecProvider.builder().automatic(true).build();
+    CodecRegistry pojoCodecRegistry = fromRegistries(getDefaultCodecRegistry(), fromProviders(pojoCodecProvider));
+
+    @Override
+    public void connect() {
+        mongoClient = MongoClients.create(connectionString);
+        mongoDatabase = mongoClient.getDatabase(databaseName).withCodecRegistry(pojoCodecRegistry);
+    }
+
+    @Override
+    public void disconnect() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @Override
+    public void saveQuiz(Quiz quiz) {
+        this.connect();
+
+        MongoCollection<Quiz> collection = mongoDatabase.getCollection("quizzes", Quiz.class);
+        collection.insertOne(quiz);
+        this.disconnect();
+    }
+
+    @Override
+    public Quiz getQuiz(String title) {
+        return null;
+    }
+
+    @Override
+    public List<String> getAllQuizzes() {
+        List<String> resultList = new ArrayList<>();
+
+        this.connect();
+
+        FindIterable<Quiz> quizzes = mongoDatabase.getCollection("quizzes", Quiz.class).find();
+
+        for (Quiz quiz : quizzes) {
+            resultList.add(quiz.toJson());
+        }
+
+        return resultList;
+    }
+}

--- a/src/entity/Note.java
+++ b/src/entity/Note.java
@@ -3,7 +3,6 @@ package entity;
 import com.google.gson.Gson;
 import org.bson.codecs.pojo.annotations.BsonCreator;
 import org.bson.codecs.pojo.annotations.BsonProperty;
-import use_case.quiz.Generator;
 import org.bson.codecs.pojo.annotations.BsonId;
 import org.bson.types.ObjectId;
 

--- a/src/entity/Quiz.java
+++ b/src/entity/Quiz.java
@@ -1,5 +1,7 @@
 package entity;
 
+import com.google.gson.Gson;
+
 import java.util.List;
 
 public class Quiz {
@@ -22,4 +24,11 @@ public class Quiz {
         this.questions = questions;
     }
 
+    public String toJson() {
+        // Create a Gson instance.
+        Gson gson = new Gson();
+
+        // Use Gson to convert the Quiz object to JSON.
+        return gson.toJson(this);
+    }
 }

--- a/src/entity/Quiz.java
+++ b/src/entity/Quiz.java
@@ -1,16 +1,34 @@
 package entity;
 
 import com.google.gson.Gson;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+import org.bson.types.ObjectId;
 
 import java.util.List;
 
 public class Quiz {
-
+    @BsonId
+    private ObjectId id;
+    private String title;
     List<Question> questions;
     int quizLength = 0;
     int numCorrect = 0;
 
-    public Quiz(){
+    public Quiz(@BsonProperty("title") String title){
+        this.title = title;
+    }
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
     }
 
     public int getQuizLength() {

--- a/src/use_case/quiz/QuizDataAccessInterface.java
+++ b/src/use_case/quiz/QuizDataAccessInterface.java
@@ -1,0 +1,13 @@
+package use_case.quiz;
+
+import entity.Quiz;
+
+import java.util.List;
+
+public interface QuizDataAccessInterface {
+    void saveQuiz(Quiz quiz);
+
+    Quiz getQuiz(String title);
+
+    List<String> getAllQuizzes();
+}

--- a/src/use_case/quiz/QuizGenerator.java
+++ b/src/use_case/quiz/QuizGenerator.java
@@ -2,7 +2,7 @@ package use_case.quiz;
 
 import entity.Quiz;
 
-public interface Generator {
+public interface QuizGenerator {
 
     Quiz createQuiz(String userPrompt);
 


### PR DESCRIPTION
Changes
- implemented `QuizDataAccessObject` and `QuizDataAccessInterface` so that all use cases associated with quiz can use this
- Added BsonId property to `Quiz`, as well as adding a title to `Quiz` (`Quiz` previously had neither a title nor an Id, which probably doesn't make a lot of sense since it would no identifier at all?)
- Renamed `Generator.java` to `QuizGenerator.java` for consistency

Please review so that Jae and I can use it for our use cases related to `Quiz`.