### PR TITLE
Open-Ended Question View Modifications

### DIFF
--- a/src/view/AnswerQuestionView.java
+++ b/src/view/AnswerQuestionView.java
@@ -31,6 +31,7 @@ public class AnswerQuestionView extends JPanel implements PropertyChangeListener
     private JTextArea questionTextArea;
     private JPanel answerPanel;
     private Map<JRadioButton, String> radioButtonValues = new HashMap<>();
+    final int maxLineLength = 55;
 
     /**
      * Constructs a new {@code AnswerQuestionView} with the specified dependencies.
@@ -167,8 +168,34 @@ public class AnswerQuestionView extends JPanel implements PropertyChangeListener
     public void setAnswerQuestionListener(AnswerQuestionListener answerQuestionListener) {
         this.answerQuestionListener = answerQuestionListener;
     }
+
     private void showFeedbackPopup(String feedback){
-        JOptionPane.showMessageDialog(this, feedback);
+        String[] lines = splitTextIntoLines(feedback);
+
+        String wrappedFeedback = String.join("<br>", lines);
+        String htmlContent = "<html>" + wrappedFeedback + "</html>";
+
+        JOptionPane.showMessageDialog(this, new JLabel(htmlContent));
+
     }
 
+    private String[] splitTextIntoLines(String text) {
+        // Split the text into lines based on the specified maxLineLength and word boundaries
+        String[] words = text.split("\\s+");
+        StringBuilder currentLine = new StringBuilder();
+        java.util.List<String> lines = new java.util.ArrayList<>();
+
+        for (String word : words) {
+            if (currentLine.length() + word.length() <= maxLineLength) {
+                currentLine.append(word).append(" ");
+            } else {
+                lines.add(currentLine.toString().trim());
+                currentLine = new StringBuilder(word + " ");
+            }
+        }
+
+        lines.add(currentLine.toString().trim());
+
+        return lines.toArray(new String[0]);
+    }
 }


### PR DESCRIPTION
Changed the open-ended question view so that the feedback does not go past the window. The original window was too big (see below).

<img width="600" alt="Screen Shot 2023-12-02 at 6 43 28 PM" src="https://github.com/vivjd/Squiz/assets/118199397/c81f02d8-d563-413b-bede-0be6fe4a2dd9">


It has now been modified to a much smaller feedback window to be consistent with the other popups:
<img width="600" alt="Screen Shot 2023-12-02 at 9 18 34 PM" src="https://github.com/vivjd/Squiz/assets/118199397/792b95e8-a344-45ac-8e02-eb8edad08631">
